### PR TITLE
Game Controller - Initialize On Startup

### DIFF
--- a/src/engine/game/g_game.cc
+++ b/src/engine/game/g_game.cc
@@ -1025,8 +1025,7 @@ dboolean G_Responder(event_t* ev) {
         }
 
         if(demoplayback && gameaction == ga_nothing) {
-            if(ev->type == ev_keydown ||
-                    ev->type == ev_gamepad) {
+            if(ev->type == ev_keydown) {
                 G_CheckDemoStatus();
                 gameaction = ga_warpquick;
                 return true;
@@ -1049,8 +1048,7 @@ dboolean G_Responder(event_t* ev) {
     if(gamestate == GS_SKIPPABLE) {
         if(gameaction == ga_nothing) {
             if(ev->type == ev_keydown ||
-                    (ev->type == ev_mouse && ev->data1) ||
-                    ev->type == ev_gamepad) {
+                    (ev->type == ev_mouse && ev->data1)) {
                 gameaction = ga_title;
                 return true;
             }


### PR DESCRIPTION
Added a fix so that the game controller is initialized on started up.  Otherwise, the game controller only works if its plugged after the game has started.  I also updated g_game.cc as the ev_gamepad events were causing the intro demo to be skipped.